### PR TITLE
Add clones and soundBank

### DIFF
--- a/types/scratch-vm.d.ts
+++ b/types/scratch-vm.d.ts
@@ -76,6 +76,8 @@ declare namespace VM {
     name: string;
     costumes: Costume[];
     sounds: Sound[];
+    clones: RenderedTarget[];
+    soundBank: AudioEngine.SoundBank | null;
   }
 
   interface Field {


### PR DESCRIPTION
Add missing `clones` and `soundBank` properties on `Sprite` interface

- #3

close #3 