### PR TITLE
Add `RenderedTargetEventMap`

### DIFF
--- a/tests/test-scratch-vm.ts
+++ b/tests/test-scratch-vm.ts
@@ -51,7 +51,7 @@ if (target) {
     const id: string = target.id;
     const x: number = fromX;
     const y: number = fromY;
-    const f: boolean | null | undefined = forced;
+    const f: boolean | undefined = forced;
   })
   target.on('EVENT_TARGET_VISUAL_CHANGE', (target) => {
     const id: string = target.id;

--- a/tests/test-scratch-vm.ts
+++ b/tests/test-scratch-vm.ts
@@ -46,6 +46,16 @@ if (target) {
     bubbleState.text.charAt(0);
     target.setCustomState('Scratch.looks', bubbleState);
   }
+
+  target.on('TARGET_MOVED', (target, fromX, fromY, forced) => {
+    const id: string = target.id;
+    const x: number = fromX;
+    const y: number = fromY;
+    const f: boolean | null | undefined = forced;
+  })
+  target.on('EVENT_TARGET_VISUAL_CHANGE', (target) => {
+    const id: string = target.id;
+  });
 } else {
   const doesNotExist: undefined = target;
 }

--- a/types/scratch-vm.d.ts
+++ b/types/scratch-vm.d.ts
@@ -1574,7 +1574,7 @@ declare class VM extends EventEmitter<VM.VirtualMachineEventMap> {
   * Emit a workspaceUpdate event.
   */
   emitWorkspaceUpdate(): void;
-   
+
   /**
    * Post sprite info to the target that's being dragged, otherwise the editing target.
    * @see {VM.Target.postSpriteInfo}

--- a/types/scratch-vm.d.ts
+++ b/types/scratch-vm.d.ts
@@ -356,7 +356,7 @@ declare namespace VM {
   }
 
   interface RenderedTargetEventMap {
-    TARGET_MOVED: [RenderedTarget, number, number, (boolean | null)?];
+    TARGET_MOVED: [RenderedTarget, number, number, boolean?];
 
     EVENT_TARGET_VISUAL_CHANGE: [RenderedTarget];
   }

--- a/types/scratch-vm.d.ts
+++ b/types/scratch-vm.d.ts
@@ -289,7 +289,7 @@ declare namespace VM {
     };
   }
 
-  interface BaseTarget extends EventEmitter<{}> {
+  interface BaseTarget extends EventEmitter<RenderedTargetEventMap> {
     runtime: Runtime;
 
     id: string;
@@ -356,7 +356,9 @@ declare namespace VM {
   }
 
   interface RenderedTargetEventMap {
-    // TODO
+    TARGET_MOVED: [RenderedTarget, number, number, (boolean | null)?];
+
+    EVENT_TARGET_VISUAL_CHANGE: [RenderedTarget];
   }
 
   const enum Effect {


### PR DESCRIPTION
I found that the `forced` was `null` when I dragged the sprite, and `undefined` when I use the "move random" block.

But, [scratch-vm](/LLK/scratch-vm) denote that is `boolean` anyway, so I typed it `(boolean | null)?`.

close: #14 