### PR TITLE
fix(scratch-render): fix scale types

### DIFF
--- a/types/scratch-render.d.ts
+++ b/types/scratch-render.d.ts
@@ -604,8 +604,8 @@ declare class RenderWebGL extends EventEmitter<RenderWebGL.ScratchRenderEventMap
   updateDrawableSkinId(drawableId: number, skinId: number): void;
   updateDrawablePosition(drawableId: number, position: [number, number]): void;
   updateDrawableDirection(drawableId: number, direction: number): void;
-  updateDrawableScale(drawableId: number, scale: number): void;
-  updateDrawableDirectionScale(drawableId: number, direction: number, scale: number): void;
+  updateDrawableScale(drawableId: number, scale: [number, number]): void;
+  updateDrawableDirectionScale(drawableId: number, direction: number, scale: [number, number]): void;
   updateDrawableVisible(drawableId: number, visible: boolean): void;
   updateDrawableEffect(drawableId: number, effectName: RenderWebGL.Effect, value: number): void;
   /**


### PR DESCRIPTION
`scale` is not a number, it's a tuple like `[number, number]`.

https://github.com/scratchfoundation/scratch-render/blob/develop/src/Drawable.js#L232